### PR TITLE
Add tip about deprecated share() method

### DIFF
--- a/knpu/container.md
+++ b/knpu/container.md
@@ -71,6 +71,18 @@ $mailer2 = $container['mailer'];
 $willBeTrue = $mailer1 === $mailer2;
 ```
 
+***TIP
+The `share()` method is deprecated and removed since Pimple 2.x version -
+you just need to use bare anonymous functions instead of wrapping them
+with `share()`:
+
+```php
+$container['session'] = function() {
+    return new Session();
+};
+```
+***
+
 This is a very common property of a service: you only ever need just one.
 If we need to send many emails, we don't need many mailers, we just need
 the one and then we'll call `send()` on it many times. This also makes our code

--- a/knpu/container.md
+++ b/knpu/container.md
@@ -72,8 +72,8 @@ $willBeTrue = $mailer1 === $mailer2;
 ```
 
 ***TIP
-The `share()` method is deprecated and removed since Pimple 2.x version -
-you just need to use bare anonymous functions instead of wrapping them
+The `share()` method is deprecated and removed since Pimple 2.0. Now, you
+simply need to use bare anonymous functions instead of wrapping them
 with `share()`:
 
 ```php


### PR DESCRIPTION
In the screencast, we use an old pimple 1.0 version, but in challenges - we use 3.0. I propose to add a TIP in this PR. So I think we have a few options here to completely fix this issue:

- Rollback Pimple version to 1.0 for challenges to be consistent with the screencast.
- Add a note to the challenges that we use Pimple 3.x and then require users to use the new syntax for sharing services.

@weaverryan I tend to the 2nd option, but what do you think?